### PR TITLE
Fix aggregation of empty stats

### DIFF
--- a/academia/curriculum/learning_task.py
+++ b/academia/curriculum/learning_task.py
@@ -794,10 +794,15 @@ class LearningStatsAggregator:
         timestamps_union = np.unique(all_timestamps)
 
         interpolated_stats = np.zeros(shape=(len(self.stats), len(timestamps_union)))
+        populated_idx = []
         for i, task_stats in enumerate(self.stats):
+            if len(task_stats) == 0 and not \
+                    (self.__includes_init_eval(task_stats) and value_domain == 'agent_evaluations'):
+                continue
+            populated_idx.append(i)
             interpolated_stats[i,:] = np.interp(
                 timestamps_union, tasks_timestamps[i], getattr(task_stats, value_domain))
-        return interpolated_stats, timestamps_union
+        return interpolated_stats[populated_idx, :], timestamps_union
 
     def __get_timestamps(self, 
                          task_stats: LearningStats,


### PR DESCRIPTION
- Closes #184 

It is possible that a task finished with empty step counts/episode rewards etc. This happens when the `min_evaluation_score` stop condition is used and it's satisfied after the initial evaluation (it happens in `LunarLander` quite often since the agent steers the craft well enough to counteract increasing wind speed). This raised some errors during the interpolation. I've fixed this by omitting stats of these tasks in aggregation unless they have `value_domain='agent_evaluations'` and they include the initial evaluation, in which case the aggregation is still possible.