### PR TITLE
Configuration files improvements & other expansions

### DIFF
--- a/academia/curriculum/config_loaders.py
+++ b/academia/curriculum/config_loaders.py
@@ -291,7 +291,10 @@ def load_curriculum_config(path: str, variables: Optional[dict] = None) -> Curri
 
     tasks = []
     for task_id in curriculum_data['order']:
-        task_raw = tasks_data[task_id]
+        try:
+            task_raw = tasks_data[task_id]
+        except KeyError:
+            raise NameError(f'Task "{task_id}" not found in the curriculum configuration.')
         if isinstance(task_raw, dict):
             task = _load_task_from_dict(task_raw)
         else:

--- a/academia/curriculum/config_loaders.py
+++ b/academia/curriculum/config_loaders.py
@@ -181,6 +181,10 @@ def load_task_config(path: str, variables: Optional[dict] = None) -> LearningTas
 
     Returns:
         A :class:`LearningTask` instance based on the configuration in the specified file.
+
+    Note:
+        For details on how to use configure tasks via YAML
+        files please refer to :ref:`config-files`.
     """
     if variables is None:
         variables = {}
@@ -268,6 +272,10 @@ def load_curriculum_config(path: str, variables: Optional[dict] = None) -> Curri
 
     Returns:
         A :class:`Curriculum` instance based on the configuration in the specified file.
+
+    Note:
+        For details on how to use configure curricula via YAML
+        files please refer to :ref:`config-files`.
     """
     if variables is None:
         variables = {}

--- a/academia/curriculum/config_loaders.py
+++ b/academia/curriculum/config_loaders.py
@@ -8,6 +8,7 @@ from . import LearningTask, Curriculum
 from academia.utils import SavableLoadable
 
 
+VARIABLE_PREFIX = '$'
 DEFAULT_ATTR_NAME = '_default'
 LOAD_ATTR_NAME = '_load'
 
@@ -54,8 +55,8 @@ def __inject_variables(config: dict, variables: dict) -> dict:
     for key, value in config.items():
         if isinstance(value, dict):
             new_config[key] = __inject_variables(config[key], variables)
-        elif isinstance(value, str) and value.startswith('$'):
-            var_name = value[1:]  # skip the dollar sign
+        elif isinstance(value, str) and value.startswith(VARIABLE_PREFIX):
+            var_name = value.removeprefix(VARIABLE_PREFIX)  # skip the dollar sign
             try:
                 new_config[key] = variables[var_name]
             except KeyError as e:

--- a/academia/curriculum/config_loaders.py
+++ b/academia/curriculum/config_loaders.py
@@ -1,9 +1,139 @@
 import os
+from typing import Optional
+import logging
 
 import yaml
 
 from . import LearningTask, Curriculum
 from academia.utils import SavableLoadable
+
+
+DEFAULT_ATTR_NAME = '_default'
+LOAD_ATTR_NAME = '_load'
+
+_logger = logging.getLogger('academia.curriculum')
+
+
+def __handle_overrides(default_config: dict, overriding_config: dict) -> dict:
+    """
+    A helper function which handles overrides to merge two configs
+
+    Args:
+        default_config: A configuration with defaults
+        overriding_config: A configuration that extends the ``default_config``
+            and may override some of its attributes
+
+    Returns:
+        A merged config
+    """
+    merged_data = default_config.copy()
+    for key, value in overriding_config.items():
+        # merge nested values
+        if isinstance(value, dict) and key in default_config.keys():
+            merged_data[key] = __handle_overrides(
+                default_config=default_config[key],
+                overriding_config=value,
+            )
+        else:
+            merged_data[key] = value
+    return merged_data
+
+
+def __inject_parameter_values(config: dict, params: dict) -> dict:
+    """
+    Substitute parameters with their values in the specified config.
+
+    Args:
+        config: Config with parameter references
+        params: Parameter values
+
+    Returns:
+        A config with parameter references substituted with their values
+    """
+    new_config = {}
+    for key, value in config.items():
+        if isinstance(value, dict):
+            new_config[key] = __inject_parameter_values(config[key], params)
+        elif isinstance(value, str) and value.startswith('$'):
+            param_name = value[1:]  # skip the dollar sign
+            try:
+                new_config[key] = params[param_name]
+            except KeyError as e:
+                raise NameError(
+                    f'A parameter named "{param_name}" was referenced in the configuration'
+                    'but no value was provided when loading the configuration'
+                ) from e
+        else:
+            # no parameters
+            new_config[key] = value
+    return new_config
+
+
+def __handle_single_load(direct_parent: dict, root_path: str) -> dict:
+    """
+    Apply the ``_load`` directive to a single dictionary.
+
+    Args:
+        direct_parent: A direct parent to the ``_load`` directive, i.e. a dictionary
+            which contains this ``_load`` key.
+        root_path: A path to the configuration file which is being loaded. This is to
+            make all paths used by ``_load`` directives relative to this file.
+
+    Returns:
+        A copy of ``direct_parent`` dict, with ``_load`` removed and external attributes
+        added (if they are missing - to allow overriding)
+    """
+    argument = direct_parent[LOAD_ATTR_NAME]
+    path = os.path.join(os.path.dirname(root_path), argument)
+    if os.path.isfile(path):
+        with open(path, 'r') as file:
+            loaded_data: dict = yaml.safe_load(file)
+        # handle _load directives in the loaded file
+        loaded_data = __handle_all_loads_from_data(
+            data=loaded_data,
+            root_path=path,
+        )
+    else:
+        raise FileNotFoundError(
+            f'Loading configuration from file {argument} failed because this file does not exist. '
+            'Check if the provided path is relative to the configuration file which is currently being read.'
+        )
+    direct_parent_copy = direct_parent.copy()
+    del direct_parent_copy[LOAD_ATTR_NAME]
+    merged_data = __handle_overrides(
+        default_config=loaded_data,
+        overriding_config=direct_parent_copy,
+    )
+    return merged_data
+
+
+def __handle_all_loads_from_data(data: dict, root_path: str) -> dict:
+    """
+    Recursively apply the ``_load`` directive for the whole current data.
+
+    Args:
+        data: Data to apply the ``_load`` for.
+        root_path: A path to the configuration file which is being loaded. This is to
+            make all paths used by ``_load`` directives relative to this file.
+
+    Returns:
+        A copy of ``data`` dict, with all ``_load`` directives handled.
+    """
+    # the reason for 'while' being here and not 'if' is because sometimes _load can load another _load,
+    # (see TestLoadTaskConfig.test_chained_load for an example case when this may occur).
+    while LOAD_ATTR_NAME in data.keys():
+        data = __handle_single_load(data, root_path)
+    # handle nested loads
+    data_processed = {}
+    for key, value in data.items():
+        if isinstance(value, dict):
+            data_processed[key] = __handle_all_loads_from_data(
+                data=value,
+                root_path=root_path,
+            )
+        else:
+            data_processed[key] = value
+    return data_processed
 
 
 def _load_task_from_dict(task_data: dict) -> 'LearningTask':
@@ -12,18 +142,21 @@ def _load_task_from_dict(task_data: dict) -> 'LearningTask':
     This is a helper method used by config loaders and it is not useful for the end user.
 
     Args:
-        task_data: dictionary that contains raw contents from the configuration file
+        task_data: dictionary that contains task configuration.
+            It is assumend that all the parameters had beed substituted with values,
+            and that any directives had been handled
 
     Returns:
         A :class:`LearningTask` instance based on the provided configuration.
     """
-    env_type = SavableLoadable.get_type(task_data['env_type'])
-    # delete env_type because it will be passed to contructor separately
-    del task_data['env_type']
+    env_type = task_data.pop('env_type')
+    # this check is now necessary because env_type can be passed directly using parameters
+    if isinstance(env_type, str):
+        env_type = SavableLoadable.get_type(env_type)
     return LearningTask(env_type=env_type, **task_data)
 
 
-def load_task_config(path: str) -> LearningTask:
+def load_task_config(path: str, params: Optional[dict] = None) -> LearningTask:
     """
     Loads a task configuration from the specified file.
 
@@ -33,26 +166,70 @@ def load_task_config(path: str) -> LearningTask:
     An example task configuration file::
 
         # my_config.task.yml
+        name: lava_crossing_hard
         env_type: academia.environments.LavaCrossing
         env_args:
             difficulty: 2
             render_mode: human
         stop_conditions:
             max_episodes: 1000
-        stats_save_path: ./my_task_stats.json
+        output_dir: .
 
     Args:
         path: Path to a configuration file.
+        params: Parameter values for the configuration file.
 
     Returns:
         A :class:`LearningTask` instance based on the configuration in the specified file.
     """
+    if params is None:
+        params = {}
+
     with open(path, 'r') as file:
         task_data: dict = yaml.safe_load(file)
+
+    task_data = __handle_all_loads_from_data(task_data, root_path=path)
+    task_data = __inject_parameter_values(task_data, params)
+
     return _load_task_from_dict(task_data)
 
 
-def load_curriculum_config(path: str) -> Curriculum:
+def __handle_default_task_config(tasks_data: dict) -> dict:
+    """
+    Provide default parameters for tasks collection if it contains a task
+    with the ID ``_default``.
+
+    Args:
+        tasks_data: Raw tasks data obtained from the curriculum configuration
+            (``tasks`` attribute)
+
+    Returns:
+        A copy of ``tasks_data`` but with defaults injected into other tasks
+        (if not overriden)
+    """
+
+    if DEFAULT_ATTR_NAME not in tasks_data.keys():
+        return tasks_data
+
+    default_task = tasks_data[DEFAULT_ATTR_NAME]
+    if not isinstance(default_task, dict):
+        # if someone passes a regular LearningTask object or anything else through a parameter
+        # as a default task, nothing can be done
+        _logger.warning(f'Default task is of an unsupported type: {type(default_task)}. '
+                        'Its attributes will not be used as defaults for other tasks.')
+        return tasks_data
+
+    # maintain default task
+    tasks_data_processed = {'_default': default_task}
+    for task_id, task_raw in tasks_data.items():
+        tasks_data_processed[task_id] = __handle_overrides(
+            default_config=default_task,
+            overriding_config=task_raw,
+        )
+    return tasks_data_processed
+
+
+def load_curriculum_config(path: str, params: Optional[dict] = None) -> Curriculum:
     """
     Loads a curriculum configuration from the specified file.
 
@@ -87,27 +264,33 @@ def load_curriculum_config(path: str) -> Curriculum:
 
     Args:
         path: Path to a configuration file.
+        params: Parameter values for the configuration file.
 
     Returns:
         A :class:`Curriculum` instance based on the configuration in the specified file.
     """
+    if params is None:
+        params = {}
+
     with open(path, 'r') as file:
         curriculum_data: dict = yaml.safe_load(file)
-    directory = os.path.dirname(path)
+
+    curriculum_data = __handle_all_loads_from_data(curriculum_data, root_path=path)
+    curriculum_data = __inject_parameter_values(curriculum_data, params)
+
+    tasks_data = curriculum_data['tasks']
+    tasks_data = __handle_default_task_config(tasks_data)
+
     tasks = []
     for task_id in curriculum_data['order']:
-        task_data: dict = curriculum_data['tasks'][task_id]
-        # tasks can be stored in two ways:
-        # 1. full task data (as stored in Curriculum.save)
-        # 2. path to a task config file (relative from curriculum file)
-        if 'path' not in task_data.keys():
-            task = _load_task_from_dict(task_data)
+        task_raw = tasks_data[task_id]
+        if isinstance(task_raw, dict):
+            task = _load_task_from_dict(task_raw)
         else:
-            task_path_abs = os.path.abspath(
-                os.path.join(directory, task_data['path'])
-            )
-            task = load_task_config(task_path_abs)
+            # task is some other object, maybe LearningTask - if not, it will raise errors later anyway
+            task = task_raw
         tasks.append(task)
+
     del curriculum_data['order']
     del curriculum_data['tasks']
     return Curriculum(tasks, **curriculum_data)

--- a/academia/curriculum/curriculum.py
+++ b/academia/curriculum/curriculum.py
@@ -1,4 +1,3 @@
-import os
 import logging
 from typing import Optional
 

--- a/academia/curriculum/curriculum.py
+++ b/academia/curriculum/curriculum.py
@@ -29,7 +29,7 @@ class Curriculum:
                 >>>     pass
 
             The parameter ``task_id`` is either the task name, or, if not specified, the order of the task's
-            execution (1 for the first task, 2 for the second, and so on).
+            execution as a string ('1' for the first task, '2' for the second, and so on).
             The callback may or may not return an agent. If it does, the returned agent will be used for
             subsequent episodes.
 

--- a/academia/curriculum/curriculum.py
+++ b/academia/curriculum/curriculum.py
@@ -100,6 +100,10 @@ class Curriculum:
         >>>     random_state=123,
         >>> )
         >>> curriculum.run(agent, verbose=4)
+
+    Note:
+        For details on how to use configure curricula via YAML
+        files please refer to :ref:`config-files`.
     """
 
     def __init__(self,

--- a/academia/curriculum/curriculum.py
+++ b/academia/curriculum/curriculum.py
@@ -93,6 +93,19 @@ class Curriculum:
     def __init__(self, tasks: list[LearningTask], output_dir: Optional[str] = None) -> None:
         self.tasks = tasks
         self.output_dir = output_dir
+        if output_dir is not None:
+            self.__ensure_tasks_savable()
+
+    def __ensure_tasks_savable(self) -> None:
+        """
+        Makes sure that each task can be saved (as long as :attr:`output_dir`
+        is specified for this curriculum).
+        """
+        for i, task in enumerate(self.tasks):
+            if task.output_dir is None:
+                task.output_dir = self.output_dir
+            if task.name is None:
+                task.name = self.__get_task_id(i)
 
     def run(self, agent: Agent, verbose=0):
         """
@@ -112,11 +125,6 @@ class Curriculum:
             task_id = self.__get_task_id(i)
             if verbose >= 1:
                 _logger.info(f'Running Task {task_id}... ')
-
-            if task.agent_save_path is None and self.output_dir is not None:
-                task.agent_save_path = os.path.join(self.output_dir, task_id)
-            if task.stats_save_path is None and self.output_dir is not None:
-                task.stats_save_path = os.path.join(self.output_dir, task_id)
 
             task.run(agent, verbose=verbose)
             total_episodes += len(task.stats.episode_rewards)

--- a/academia/curriculum/curriculum.py
+++ b/academia/curriculum/curriculum.py
@@ -49,8 +49,8 @@ class Curriculum:
 
         Initializaton using a config file:
 
-        >>> from academia.curriculum import Curriculum
-        >>> curriculum = Curriculum.load('./my_config.curriculum.yml')
+        >>> from academia.curriculum import load_curriculum_config
+        >>> curriculum = load_curriculum_config('./my_config.curriculum.yml')
 
         ``./my_config.curriculum.yml``::
 

--- a/academia/curriculum/learning_task.py
+++ b/academia/curriculum/learning_task.py
@@ -384,6 +384,7 @@ class LearningTask:
         for predicate in self.__initialised_stop_predicates:
             if predicate(stats=self.stats):
                 return True
+        return False
 
 
 class LearningStats(SavableLoadable):

--- a/academia/curriculum/learning_task.py
+++ b/academia/curriculum/learning_task.py
@@ -236,17 +236,13 @@ class LearningTask:
         """
         try:
             self.__train_agent(agent, verbose)
-        except KeyboardInterrupt:
-            if verbose >= 1:
-                _logger.info('Training interrupted.')
-            self.__handle_task_terminated(agent, verbose, interrupted=True)
-            sys.exit(130)
         except Exception as e:
             if verbose >= 1:
                 _logger.info('Training interrupted.')
             _logger.exception(e)
             self.__handle_task_terminated(agent, verbose, interrupted=True)
-            sys.exit(1)
+            exit_code = 130 if isinstance(e, KeyboardInterrupt) else 1
+            sys.exit(exit_code)
         else:
             if verbose >= 1:
                 _logger.info('Training finished.')

--- a/academia/curriculum/learning_task.py
+++ b/academia/curriculum/learning_task.py
@@ -141,9 +141,9 @@ class LearningTask:
         >>> )
         >>> task.run(agent, verbose=4)
 
-        Using callbacks:
-
-
+    Note:
+        For details on how to use configure tasks via YAML
+        files please refer to :ref:`config-files`.
     """
 
     stop_predicates: dict[str, Callable[[Any, 'LearningStats'], bool]] = {

--- a/academia/curriculum/learning_task.py
+++ b/academia/curriculum/learning_task.py
@@ -67,8 +67,6 @@ class LearningTask:
             start of the :func:`run` method). Defaults to ``True``.
         greedy_evaluation: Whether or not the evaluation should be performed in greedy mode.
             Defaults to ``True``.
-        exploration_reset_value: If specified, agent's exploration parameter will get updated to that value
-            after the task is finished. Unspecified by default.
         episode_callback: A function to be called after each episode is finished. It should have the
             following signature::
 
@@ -200,7 +198,6 @@ class LearningTask:
                  evaluation_count: int = 25,
                  include_init_eval: bool = True,
                  greedy_evaluation: bool = True,
-                 exploration_reset_value: Optional[float] = None,
                  episode_callback: Optional[Callable] = None,
                  name: Optional[str] = None,
                  output_dir: Optional[str] = None,
@@ -232,7 +229,6 @@ class LearningTask:
         self.__evaluation_count = evaluation_count
         self.__include_init_eval = include_init_eval
         self.__greedy_evaluation = greedy_evaluation
-        self.__exploration_reset_value = exploration_reset_value
         self.__episode_callback = episode_callback
 
         self.stats = LearningStats(self.__evaluation_interval)
@@ -306,9 +302,6 @@ class LearningTask:
                 new_agent = self.__episode_callback(agent, self.stats, episode)
                 if new_agent is not None:
                     agent = new_agent
-
-        if self.__exploration_reset_value is not None:
-            agent.reset_exploration(self.__exploration_reset_value)
 
     def __run_episode(self, agent: Agent, evaluation_mode: bool = False) -> tuple[float, int]:
         """

--- a/academia/curriculum/learning_task.py
+++ b/academia/curriculum/learning_task.py
@@ -106,7 +106,7 @@ class LearningTask:
 
         Initializaton using a config file:
 
-        >>> from academia.curriculum import LearningTask, load_task_config
+        >>> from academia.curriculum import load_task_config
         >>> task = load_task_config('./my_config.task.yml')
 
         ``./my_config.task.yml``::

--- a/academia/environments/lunar_lander.py
+++ b/academia/environments/lunar_lander.py
@@ -12,7 +12,7 @@ class LunarLander(GenericGymnasiumWrapper):
     a variant of the classic Lunar Lander game.
 
     The goal is to land a spacecraft on the moon's surface by controlling its thrusters.
-    The environment has a state size of 8 and 4 possible actions.
+    The environment has a state size of 7 and 4 possible actions.
     The difficulty ranges from 0 to 5, with higher values indicating more challenging conditions.
     The environment can be rendered in different modes.
 

--- a/academia/environments/lunar_lander.py
+++ b/academia/environments/lunar_lander.py
@@ -12,7 +12,7 @@ class LunarLander(GenericGymnasiumWrapper):
     a variant of the classic Lunar Lander game.
 
     The goal is to land a spacecraft on the moon's surface by controlling its thrusters.
-    The environment has a state size of 7 and 4 possible actions.
+    The environment has a state size of 8 and 4 possible actions.
     The difficulty ranges from 0 to 5, with higher values indicating more challenging conditions.
     The environment can be rendered in different modes.
 

--- a/academia/environments/ms_pacman.py
+++ b/academia/environments/ms_pacman.py
@@ -30,11 +30,11 @@ class MsPacman(GenericAtariWrapper):
     +-----+-----------+----------------+
     | 5   | UPRIGHT   | Move upright   |
     +-----+-----------+----------------+
-    | 6   | UPLEFT    | Move upleft    |
+    | 7   | UPLEFT    | Move upleft    |
     +-----+-----------+----------------+
-    | 7   | DOWNRIGHT | Move downright |
+    | 6   | DOWNRIGHT | Move downright |
     +-----+-----------+----------------+
-    | 8   | DOWNLEFT  | Move downleft  |
+    | 7   | DOWNLEFT  | Move downleft  |
     +-----+-----------+----------------+
 
     Difficulty levels:

--- a/academia/environments/ms_pacman.py
+++ b/academia/environments/ms_pacman.py
@@ -30,11 +30,11 @@ class MsPacman(GenericAtariWrapper):
     +-----+-----------+----------------+
     | 5   | UPRIGHT   | Move upright   |
     +-----+-----------+----------------+
-    | 7   | UPLEFT    | Move upleft    |
+    | 6   | UPLEFT    | Move upleft    |
     +-----+-----------+----------------+
-    | 6   | DOWNRIGHT | Move downright |
+    | 7   | DOWNRIGHT | Move downright |
     +-----+-----------+----------------+
-    | 7   | DOWNLEFT  | Move downleft  |
+    | 8   | DOWNLEFT  | Move downleft  |
     +-----+-----------+----------------+
 
     Difficulty levels:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,7 +18,7 @@ sys.path.insert(0, os.path.abspath('..'))
 # -- Project information -----------------------------------------------------
 
 project = 'academia'
-copyright = '2023, krezelj, Szymon-Gut, maciejors'
+copyright = '2024, krezelj, Szymon-Gut, maciejors'
 author = 'krezelj, Szymon-Gut, maciejors'
 
 

--- a/docs/guides/configuration-files/codes/1-code-init.py
+++ b/docs/guides/configuration-files/codes/1-code-init.py
@@ -1,0 +1,20 @@
+from academia.curriculum import LearningTask, Curriculum
+from academia.environments import LavaCrossing
+
+# define tasks
+task1 = LearningTask(
+    env_type=LavaCrossing,
+    env_args={'difficulty': 0, 'render_mode': 'human', 'append_step_count': True},
+    stop_conditions={'max_episodes': 500},
+)
+task2 = LearningTask(
+    env_type=LavaCrossing,
+    env_args={'difficulty': 1, 'render_mode': 'human', 'append_step_count': True},
+    stop_conditions={'max_episodes': 1000},
+)
+
+# define a curriculum
+curriculum = Curriculum(
+    tasks=[task1, task2],
+    output_dir='./my_curriculum/',
+)

--- a/docs/guides/configuration-files/codes/10/doorkey.task.yml
+++ b/docs/guides/configuration-files/codes/10/doorkey.task.yml
@@ -1,0 +1,10 @@
+env_type: academia.environments.DoorKey
+env_args:
+  difficulty: 0
+  append_step_count: True
+  random_state: $env_random_state
+stop_conditions:
+  min_evaluation_score: 0.9
+evaluation_interval: 100
+evaluation_count: 25
+include_init_eval: True

--- a/docs/guides/configuration-files/codes/10/run.py
+++ b/docs/guides/configuration-files/codes/10/run.py
@@ -1,0 +1,11 @@
+from academia.curriculum import load_task_config
+
+stats = []
+
+for run_no in range(10):
+    agent = ...  # initialise some agent here
+    task = load_task_config('./doorkey.task.yml', variables={
+        'env_random_state': run_no,
+    })
+    task.run(agent)
+    stats.append(stats)

--- a/docs/guides/configuration-files/codes/11/my_curriculum.yml
+++ b/docs/guides/configuration-files/codes/11/my_curriculum.yml
@@ -1,0 +1,22 @@
+output_dir: './my_curriculum/'
+task_callback: $task_callback
+order:
+- 0
+- 1
+tasks:
+  _default:
+    env_args:
+      render_mode: human
+      append_step_count: True
+    env_type: academia.environments.LavaCrossing
+    evaluation_interval: 100
+  0:
+    env_args:
+      difficulty: 0
+    stop_conditions:
+      max_episodes: 500
+  1:
+    env_args:
+      difficulty: 1
+    stop_conditions:
+      max_episodes: 1000

--- a/docs/guides/configuration-files/codes/11/run.py
+++ b/docs/guides/configuration-files/codes/11/run.py
@@ -1,0 +1,11 @@
+from academia.agents.base import Agent
+from academia.curriculum import LearningStats, load_curriculum_config
+
+
+def my_task_callback(agent: Agent, stats: LearningStats, task_id: str) -> None:
+    agent.reset_exploration(0.8)
+
+
+task = load_curriculum_config('my_curriculum.yml', variables={
+    'task_callback': my_task_callback,
+})

--- a/docs/guides/configuration-files/codes/2/load.py
+++ b/docs/guides/configuration-files/codes/2/load.py
@@ -1,0 +1,3 @@
+from academia.curriculum import load_curriculum_config
+
+curriculum = load_curriculum_config('my_config.curriculum.yml')

--- a/docs/guides/configuration-files/codes/2/my_config.curriculum.yml
+++ b/docs/guides/configuration-files/codes/2/my_config.curriculum.yml
@@ -1,0 +1,23 @@
+output_dir: './my_curriculum/'
+order:
+- 0
+- 1
+tasks:
+  0:
+    env_args:
+      difficulty: 0
+      render_mode: human
+      append_step_count: True
+    env_type: academia.environments.LavaCrossing
+    evaluation_interval: 100
+    stop_conditions:
+      max_episodes: 500
+  1:
+    env_args:
+      difficulty: 1
+      render_mode: human
+      append_step_count: True
+    env_type: academia.environments.LavaCrossing
+    evaluation_interval: 100
+    stop_conditions:
+      max_episodes: 1000

--- a/docs/guides/configuration-files/codes/3-default-excluded.yml
+++ b/docs/guides/configuration-files/codes/3-default-excluded.yml
@@ -1,0 +1,21 @@
+output_dir: './my_curriculum/'
+order:
+- 0
+- 1
+tasks:
+  _default:
+    env_args:
+      render_mode: human
+      append_step_count: True
+    env_type: academia.environments.LavaCrossing
+    evaluation_interval: 100
+  0:
+    env_args:
+      difficulty: 0
+    stop_conditions:
+      max_episodes: 500
+  1:
+    env_args:
+      difficulty: 1
+    stop_conditions:
+      max_episodes: 1000

--- a/docs/guides/configuration-files/codes/4-default-included.yml
+++ b/docs/guides/configuration-files/codes/4-default-included.yml
@@ -1,0 +1,19 @@
+output_dir: './my_curriculum/'
+order:
+- easier
+- _default
+tasks:
+  _default:
+    env_args:
+      difficulty: 1
+      render_mode: human
+      append_step_count: True
+    env_type: academia.environments.LavaCrossing
+    evaluation_interval: 100
+    stop_conditions:
+      max_episodes: 1000
+  easier:
+    env_args:
+      difficulty: 0
+    stop_conditions:
+      max_episodes: 500

--- a/docs/guides/configuration-files/codes/5/full.curriculum.yml
+++ b/docs/guides/configuration-files/codes/5/full.curriculum.yml
@@ -1,0 +1,26 @@
+order:
+  - 0
+  - 1
+  - 2
+tasks:
+  _default:
+    env_type: academia.environments.DoorKey
+    stop_conditions:
+      min_evaluation_score: 0.9
+    evaluation_interval: 100
+    evaluation_count: 25
+    include_init_eval: True
+  0:
+    name: 'Easy task'
+    env_args:
+      difficulty: 0
+  1:
+    name: 'Intermediate task'
+    env_args:
+      difficulty: 1
+  2:
+    name: 'Hard task'
+    env_args:
+      difficulty: 2
+    stop_conditions:
+      max_episodes: 1000

--- a/docs/guides/configuration-files/codes/5/task-skip.curriculum.yml
+++ b/docs/guides/configuration-files/codes/5/task-skip.curriculum.yml
@@ -1,0 +1,21 @@
+order:
+  - 0
+  - 2
+tasks:
+  _default:
+    env_type: academia.environments.DoorKey
+    stop_conditions:
+      min_evaluation_score: 0.9
+    evaluation_interval: 100
+    evaluation_count: 25
+    include_init_eval: True
+  0:
+    name: 'Easy task'
+    env_args:
+      difficulty: 0
+  2:
+    name: 'Hard task'
+    env_args:
+      difficulty: 2
+    stop_conditions:
+      max_episodes: 1000

--- a/docs/guides/configuration-files/codes/6/easy.task.yml
+++ b/docs/guides/configuration-files/codes/6/easy.task.yml
@@ -1,0 +1,3 @@
+name: 'Easy task'
+env_args:
+  difficulty: 0

--- a/docs/guides/configuration-files/codes/6/full.curriculum.yml
+++ b/docs/guides/configuration-files/codes/6/full.curriculum.yml
@@ -1,0 +1,18 @@
+order:
+  - 0
+  - 1
+  - 2
+tasks:
+  _default:
+    env_type: academia.environments.DoorKey
+    stop_conditions:
+      min_evaluation_score: 0.9
+    evaluation_interval: 100
+    evaluation_count: 25
+    include_init_eval: True
+  0:
+    _load: ./easy.task.yml
+  1:
+    _load: ./intermediate.task.yml
+  2:
+    _load: ./hard.task.yml

--- a/docs/guides/configuration-files/codes/6/hard.task.yml
+++ b/docs/guides/configuration-files/codes/6/hard.task.yml
@@ -1,0 +1,5 @@
+name: 'Hard task'
+env_args:
+  difficulty: 2
+stop_conditions:
+  max_episodes: 1000

--- a/docs/guides/configuration-files/codes/6/intermediate.task.yml
+++ b/docs/guides/configuration-files/codes/6/intermediate.task.yml
@@ -1,0 +1,3 @@
+name: 'Intermediate task'
+env_args:
+  difficulty: 1

--- a/docs/guides/configuration-files/codes/6/task-skip.curriculum.yml
+++ b/docs/guides/configuration-files/codes/6/task-skip.curriculum.yml
@@ -1,0 +1,15 @@
+order:
+  - 0
+  - 2
+tasks:
+  _default:
+    env_type: academia.environments.DoorKey
+    stop_conditions:
+      min_evaluation_score: 0.9
+    evaluation_interval: 100
+    evaluation_count: 25
+    include_init_eval: True
+  0:
+    _load: ./easy.task.yml
+  2:
+    _load: ./hard.task.yml

--- a/docs/guides/configuration-files/codes/7/full.curriculum.yml
+++ b/docs/guides/configuration-files/codes/7/full.curriculum.yml
@@ -1,0 +1,13 @@
+order:
+  - 0
+  - 1
+  - 2
+tasks:
+  _default:
+    _load: ./task-defaults.yml
+  0:
+    _load: ./easy.task.yml
+  1:
+    _load: ./intermediate.task.yml
+  2:
+    _load: ./hard.task.yml

--- a/docs/guides/configuration-files/codes/7/task-defaults.yml
+++ b/docs/guides/configuration-files/codes/7/task-defaults.yml
@@ -1,0 +1,6 @@
+env_type: academia.environments.DoorKey
+stop_conditions:
+  min_evaluation_score: 0.9
+evaluation_interval: 100
+evaluation_count: 25
+include_init_eval: True

--- a/docs/guides/configuration-files/codes/8-full-override.curriculum.yml
+++ b/docs/guides/configuration-files/codes/8-full-override.curriculum.yml
@@ -1,0 +1,15 @@
+order:
+  - 0
+  - 1
+  - 2
+tasks:
+  _default:
+    _load: ./task-defaults.yml
+    # this will override the evaluation_count of 25 from ./task-defaults.yml:
+    evaluation_count: 10
+  0:
+    _load: ./easy.task.yml
+  1:
+    _load: ./intermediate.task.yml
+  2:
+    _load: ./hard.task.yml

--- a/docs/guides/configuration-files/codes/9/doorkey.task.yml
+++ b/docs/guides/configuration-files/codes/9/doorkey.task.yml
@@ -1,0 +1,10 @@
+env_type: academia.environments.DoorKey
+env_args:
+  difficulty: 0
+  append_step_count: True
+  random_state: 123
+stop_conditions:
+  min_evaluation_score: 0.9
+evaluation_interval: 100
+evaluation_count: 25
+include_init_eval: True

--- a/docs/guides/configuration-files/codes/9/run.py
+++ b/docs/guides/configuration-files/codes/9/run.py
@@ -1,0 +1,9 @@
+from academia.curriculum import load_task_config
+
+stats = []
+
+for run_no in range(10):
+    agent = ...  # initialise some agent here
+    task = load_task_config('./doorkey.task.yml')
+    task.run(agent)
+    stats.append(task.stats)

--- a/docs/guides/configuration-files/index.rst
+++ b/docs/guides/configuration-files/index.rst
@@ -1,0 +1,256 @@
+.. currentmodule:: academia.curriculum
+
+.. _config-files:
+
+Configuring tasks & curricula
+-----------------------------
+
+Intro
+=====
+
+In *academia* package, there are two ways of initializing tasks and curricula.
+The first method is through the use of :class:`LearningTask` and
+:class:`Curriculum`'s constructors. The other utilizes configuration files in the YAML
+format and :func:`load_task_config` or :func:`load_curriculum_config` functions.
+
+Here is an example of initializing a simple curriculum directly in a script:
+
+.. literalinclude:: codes/1-code-init.py
+  :linenos:
+
+This code creates a curriculum which comprises the first two levels of the Lava Crossing
+environment. An identical curriculum can be defined with the following configuration file:
+
+.. literalinclude:: codes/2/my_config.curriculum.yml
+  :language: YAML
+  :linenos:
+  :caption: my_config.curriculum.yml
+
+This can be then loaded with a single line of code:
+
+.. literalinclude:: codes/2/load.py
+  :linenos:
+
+Neither method is better than the other and it is up to the user to choose which
+one they prefer.
+Initializing through code gives more flexibility and can be easier for users not
+familiar with *academia*'s API. On the other hand, configuration files allow to
+extract most of the configuration logic out of the source code. They can also make large
+and complex configurations more concise and readable, which might make them
+a better option for more complex experiments.
+
+To learn about the specific parameters for environments, tasks and curricula,
+feel free to explore the rest of the documentation to get familiar with
+*academia*'s functions and classes. The rest of this guide will focus on YAML
+configuration files. More specifically, we will explore some special features
+which make this method flexible and allow users to avoid duplication in
+their configuraions.
+
+.. note::
+   While the configuration has to be in the YAML format, *academia* does not
+   enforce any particular file extensions. However, it is often a good practise
+   to differentiate task and curricula configuration files by using extensions
+   such as ``.task.yml`` or ``.curriculum.yml``.
+
+Default task parameters inside a curriculum
+===========================================
+
+Tasks inside a single curriculum often share similar sets of parameter values.
+For example, all of them could utilize the same environment, but with
+different difficulty levels. Curriculum configuration file allows to
+define a set of default parameters for tasks inside that curriculum.
+
+In the example configuration above, both tasks share a lot of the same
+configuration, which leads to lots of code duplication.
+Below are highlighted the only unique pieces of configuration for
+both tasks:
+
+.. literalinclude:: codes/2/my_config.curriculum.yml
+  :language: YAML
+  :linenos:
+  :emphasize-lines: 8,14,17,23
+
+To address this issue, a special ``_default`` task can be defined for
+the curriculum, which provides default parameters values for all tasks
+defined or loaded in this curriculum (more on loading later). The
+configuration listed above can be simplified in the following way:
+
+.. literalinclude:: codes/3-default-excluded.yml
+  :language: YAML
+  :linenos:
+
+Now, all common configuration has been moved to the ``_default`` task, and
+the tasks define only their unique arguments. Note that the ``_default`` task
+can also be used in the curriculum, just as any other task. All we need to do
+is to supply all required parameters to it. Consider the following configuration,
+which again is equivalent to the ones listed before:
+
+.. literalinclude:: codes/4-default-included.yml
+  :language: YAML
+  :linenos:
+
+In curriculum learning, the final environment is treated as the most important one,
+and all other tasks are only there to speed up the training. It makes sense then to
+mark the target environment as ``_default`` in the configuration, and then for easier
+tasks define just their unique pieces of configuration. This is exactly what we do
+in the above example. Notice that both ``_default`` and ``easier`` tasks define
+the environment difficulty, as well as a max episodes stop condition. Each task can
+override the default configuration, and this is exactly what happens here.
+For instance, the ``easier`` task is now going to end after 500 episodes -
+if we did not specify this stop condition here, it would end after 1000 episodes,
+just as declared in the ``_default`` task.
+
+Loading configurations from external files
+==========================================
+
+It is not uncommon for multiple curricula to share common tasks. Let us say we want to
+design two curricula for the Door Key environment. Consider the difficulty level
+of 2 as the target difficulty for this environment. In the first curriculum, we want
+an agent to go through all the difficulty levels up to the level 2, starting at level 0.
+In the other curriculum, we want it to skip the level 1 and go straight from level 0 to
+level 2. Below are example configurations for both scenarios:
+
+.. literalinclude:: codes/5/full.curriculum.yml
+  :language: YAML
+  :linenos:
+  :caption: full.curriculum.yml
+
+.. literalinclude:: codes/5/task-skip.curriculum.yml
+  :language: YAML
+  :linenos:
+  :caption: task-skip.curriculum.yml
+
+We use the ``_default`` task to avoid configuration duplication in each of the
+files. Still, the configurations for tasks named "Easy task" and "Hard task" are identical
+in both files. It would be nice to somehow extract it to a separate file, and load it in
+both of the above's configurations. Luckily, we can do it using the special attribute
+named ``_load``. It tells the configuration loaders to load YAML attributes from another
+file. This way, we can split the above configurations into multiple files to create
+an equivalent configuration:
+
+.. literalinclude:: codes/6/easy.task.yml
+  :language: YAML
+  :linenos:
+  :caption: easy.task.yml
+
+.. literalinclude:: codes/6/intermediate.task.yml
+  :language: YAML
+  :linenos:
+  :caption: intermediate.task.yml
+
+.. literalinclude:: codes/6/hard.task.yml
+  :language: YAML
+  :linenos:
+  :caption: hard.task.yml
+
+.. literalinclude:: codes/6/full.curriculum.yml
+  :language: YAML
+  :linenos:
+  :caption: full.curriculum.yml
+  :emphasize-lines: 14,16,18
+
+.. literalinclude:: codes/6/task-skip.curriculum.yml
+  :language: YAML
+  :linenos:
+  :caption: task-skip.curriculum.yml
+  :emphasize-lines: 13,15
+
+Note that the path provided for the ``_load`` attribute must be relative to the
+current configuration file.
+
+The ``_load`` special attribute can be used not just to load tasks. It is designed to be
+able to load attributes from any YAML file, which makes it very versatile. For example,
+in the above configurations, since the ``_default`` task is also shared across both curricula,
+we could extract its parameters into a separate file. It could look as follows
+for full curriculum (analogously for the task-skip curriculum):
+
+.. literalinclude:: codes/7/task-defaults.yml
+  :language: YAML
+  :linenos:
+  :caption: task-defaults.yml
+
+.. literalinclude:: codes/7/full.curriculum.yml
+  :language: YAML
+  :linenos:
+  :caption: full.curriculum.yml
+  :emphasize-lines: 7
+
+The ``_load`` special attribute could also be chained, i.e. you can load a file, which
+has ``_load`` in it, and it will also be handled. Also, just like with the ``_default``
+task, attributes loaded with the ``_load`` can be overriden if you specify them
+alongside the ``_load`` attribute:
+
+.. literalinclude:: codes/8-full-override.curriculum.yml
+  :language: YAML
+  :linenos:
+  :caption: full.curriculum.yml
+  :emphasize-lines: 8,9
+
+This is just one way to transform these configurations, and there could possibly be even
+better ways to structure them. Remember that the ``_load`` special attribute can be used in
+both tasks and curricula configurations.
+
+Variables in configuration files
+================================
+
+So far all configuration files we looked at had all the parameter values hardcoded. There
+could be cases however when we might want to input some of the parameters dynamically.
+For example, let us say we want to run a task 10 times to be able to average the results
+of our experiment across different independent runs. Consider the following configuration
+file and script:
+
+.. literalinclude:: codes/9/doorkey.task.yml
+  :language: YAML
+  :linenos:
+  :caption: doorkey.task.yml
+
+.. literalinclude:: codes/9/run.py
+  :linenos:
+  :caption: run.py
+
+Note that we specify a random state to the Door Key environment to ensure reproducibility
+of our experiments. However, it could be better to pass a different random seed to the
+environment for each individual run. We can achieve this using variables inside our
+configuration. Variables are marked by a dollar sign ``$`` in the configuration files
+and can be used as follows:
+
+.. literalinclude:: codes/10/doorkey.task.yml
+  :language: YAML
+  :linenos:
+  :caption: doorkey.task.yml
+  :emphasize-lines: 5
+
+.. literalinclude:: codes/10/run.py
+  :linenos:
+  :caption: run.py
+  :emphasize-lines: 7,8,9
+
+The same syntax applies for the :func:`load_curriculum_config` function. Variables can also be
+used in external files loaded via the ``_load`` attribute - the same ``variables`` dictionary
+will be used to resolve variables in any loaded files.
+
+Variables can also be useful in setting parameters which are not possible to be set directly
+in the configuration files. Good examples of such parameters are ``task_callback`` for
+:class:`Curriculum` and ``episode_callback`` for :class:`LearningTask`. In the following
+example, we use a variable to configure the former:
+
+.. literalinclude:: codes/11/my_curriculum.yml
+  :language: YAML
+  :linenos:
+  :caption: my_curriculum.yml
+  :emphasize-lines: 2
+
+.. literalinclude:: codes/11/run.py
+  :linenos:
+  :caption: run.py
+  :emphasize-lines: 9,10,11
+
+These examples provide just the most common use cases. Variables have
+also been designed with versitality in mind, and could also be used to
+specify full tasks inside a curriculum, or to order tasks in a curriculum.
+Basically, any attribute in the configuration (except for ``_load``) can have a
+variable assigned to it with a value provided at runtime upon loading.
+
+.. note::
+   Variables cannot be used to dynamically provide paths for the ``_load`` attribute.
+   This is because by design all loads are handled before variables are resolved.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,6 +23,7 @@ This package's purpose is to provide easy-to-use tools for `Curriculum Learning`
    :caption: Guides
 
    guides/custom-environments
+   guides/configuration-files/index
 
 =======
 Indices

--- a/test/curriculum/test_config_loaders.py
+++ b/test/curriculum/test_config_loaders.py
@@ -13,7 +13,8 @@ from academia.utils import SavableLoadable
 
 def _mock_load_task_config(path: str):
     with open(path, 'r') as file:
-        name = file.readline()
+        # first line is something like this: "name: my_name"
+        name = file.readline()[6:]
     mock_task = mock.MagicMock()
     mock_task.name = name
     return mock_task
@@ -97,10 +98,9 @@ class TestLoadCurriculumConfig(unittest.TestCase):
         self.assertEqual('Gary Cahill', sut.tasks[1].name)
         self.assertEqual(2, len(sut.tasks))
 
-    def test_load_directive_path(self):
+    def test_load(self):
         """
-        The ``_load`` directive should load task configuration from a separate file if
-        the value for the directive is a path
+        The ``_load`` directive should load task configuration from a separate file
         """
         with tempfile.TemporaryDirectory() as temp_dir:
             os.mkdir(os.path.join(temp_dir, 'curricula'))
@@ -118,40 +118,16 @@ class TestLoadCurriculumConfig(unittest.TestCase):
                 f.write(curriculum_config)
             with open(os.path.join(temp_dir, 'tasks/3.task.yml'), 'w') as f:
                 # super simplified task config for mock LearningTask.load()
-                f.write("Craig Forsyth")
+                f.write("name: Craig Forsyth")
             # act
             sut = load_curriculum_config(config_file_path)
         # assert
         self.assertEqual('Craig Forsyth', sut.tasks[0].name)
 
-    def test_load_directive_internal(self):
+    def test_default_task_config(self):
         """
-        The ``_load`` directive should load other task's configuration from the same
-        ``Curriculum`` if the value for the directive is a task ID
-        """
-        with tempfile.TemporaryDirectory() as temp_dir:
-            # arrange
-            curriculum_config = (
-                "order:\n"
-                "  - 1\n"
-                "tasks:\n"  # simplified task config
-                "  base_task:\n"
-                "    name: Petr Cech\n"
-                "  1:\n"
-                "    _load: base_task"
-            )
-            config_file_path = os.path.join(temp_dir, 'config.curriculum.yml')
-            with open(config_file_path, 'w') as f:
-                f.write(curriculum_config)
-            # act
-            sut = load_curriculum_config(config_file_path)
-        # assert
-        self.assertEqual('Petr Cech', sut.tasks[0].name)
-
-    def test_load_directive_override(self):
-        """
-        When using the ``_load`` directive and specifying other attributes as well, the specified
-        attributes should override the ones specified in the loaded task
+        Attributes defined inside the ``_default`` task should carry over to all other tasks
+        unless explicitly overriden
         """
         with tempfile.TemporaryDirectory() as temp_dir:
             # arrange
@@ -159,11 +135,10 @@ class TestLoadCurriculumConfig(unittest.TestCase):
                 "order:\n"
                 "  - 1\n"
                 "tasks:\n"  # simplified task config
-                "  base_task:\n"
+                "  _default:\n"
                 "    name: base_name\n"
                 "    output_dir: ./tasks\n"
                 "  1:\n"
-                "    _load: base_task\n"
                 "    name: new_name"
             )
             config_file_path = os.path.join(temp_dir, 'config.curriculum.yml')
@@ -195,11 +170,11 @@ class TestLoadCurriculumConfig(unittest.TestCase):
             # act
             sut = load_curriculum_config(config_file_path, params={
                 'out': './my_curriculum',
-                'name': 'Petr Cech',
+                'name': 'Alfie May is a baller',
             })
         # assert
         self.assertEqual('./my_curriculum', sut.output_dir)
-        self.assertEqual('Petr Cech', sut.tasks[0].name)
+        self.assertEqual('Alfie May is a baller', sut.tasks[0].name)
 
     def test_parameter_missing(self):
         """
@@ -224,9 +199,9 @@ class TestLoadCurriculumConfig(unittest.TestCase):
                     'out': './my_curriculum',
                 })
 
-    def test_parameterised_full_tasks(self):
+    def test_parameterised_full_tasks_data(self):
         """
-        A curriculum task should be able to be loaded from a parameter
+        A curriculum task data should be able to be loaded from a parameter
         """
         with tempfile.TemporaryDirectory() as temp_dir:
             # arrange
@@ -241,7 +216,29 @@ class TestLoadCurriculumConfig(unittest.TestCase):
                 f.write(curriculum_config)
             # act
             sut = load_curriculum_config(config_file_path, params={
-                'my_task': _mock_load_task_from_dict({'name': 'super_task'})
+                'my_task': {'name': 'super_task'},
+            })
+        # assert
+        self.assertEqual('super_task', sut.tasks[0].name)
+
+    def test_parameterised_full_tasks_obj(self):
+        """
+        A curriculum task should be able to be loaded from a parameter directly as an object
+        """
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # arrange
+            curriculum_config = (
+                "order:\n"
+                "  - 1\n"
+                "tasks:\n"  # simplified task config
+                "  1: $my_task\n"
+            )
+            config_file_path = os.path.join(temp_dir, 'config.curriculum.yml')
+            with open(config_file_path, 'w') as f:
+                f.write(curriculum_config)
+            # act
+            sut = load_curriculum_config(config_file_path, params={
+                'my_task': _mock_load_task_from_dict({'name': 'super_task'}),
             })
         # assert
         self.assertEqual('super_task', sut.tasks[0].name)
@@ -265,37 +262,12 @@ class TestLoadCurriculumConfig(unittest.TestCase):
                 f.write(curriculum_config)
             # act
             sut = load_curriculum_config(config_file_path, params={
-                'my_order': ['1', '24']
+                'my_order': [1, 24]
             })
         # assert
         self.assertEqual('Petr Cech', sut.tasks[0].name)
         self.assertEqual('Gary Cahill', sut.tasks[1].name)
         self.assertEqual(2, len(sut.tasks))
-
-    def test_load_directive_with_parameters(self):
-        """
-        Parameters should be loaded for tasks which use the ``_load`` directive
-        """
-        with tempfile.TemporaryDirectory() as temp_dir:
-            # arrange
-            curriculum_config = (
-                "order:\n"
-                "  - 1\n"
-                "tasks:\n"  # simplified task config
-                "  base_task:\n"
-                "    name: $name\n"
-                "  1:\n"
-                "    _load: base_task"
-            )
-            config_file_path = os.path.join(temp_dir, 'config.curriculum.yml')
-            with open(config_file_path, 'w') as f:
-                f.write(curriculum_config)
-            # act
-            sut = load_curriculum_config(config_file_path, params={
-                'name': 'parametrised_name'
-            })
-        # assert
-        self.assertEqual('parametrised_name', sut.tasks[0].name)
 
 
 @mock.patch(
@@ -350,7 +322,7 @@ class TestLoadTaskConfig(unittest.TestCase):
         # stop condition
         self.assertEqual(2, len(sut.stats.episode_rewards))
 
-    def test_load_directive(self, mock_env: ScalableEnvironment, mock_agent: Agent):
+    def test_load(self, mock_env: ScalableEnvironment, mock_agent: Agent):
         """
         The ``_load`` directive should load and allow to override other task configuration
         """
@@ -389,6 +361,49 @@ class TestLoadTaskConfig(unittest.TestCase):
         # stop condition
         self.assertEqual(2, len(sut.stats.episode_rewards))
 
+    def test_chained_load(self, mock_env: ScalableEnvironment, mock_agent: Agent):
+        """
+        The ``_load`` directive should be handled in loaded files as well (chaining)
+        """
+        with tempfile.TemporaryDirectory() as temp_dir:
+            first_config = (
+                "name: base_name\n"
+            )
+            second_config = (
+                "_load: ./first.task.yml\n"
+                "evaluation_interval: 24\n"
+            )
+            third_config = (
+                "_load: ./second.task.yml\n"
+                "env_type: placeholder\n"
+                "env_args:\n"
+                "  difficulty: 0\n"
+                "stop_conditions:\n"
+                "  max_episodes: 2\n"
+                f"output_dir: {temp_dir}/out\n"
+            )
+            with open(os.path.join(temp_dir, 'first.task.yml'), 'w') as f:
+                f.write(first_config)
+            with open(os.path.join(temp_dir, 'second.task.yml'), 'w') as f:
+                f.write(second_config)
+            final_config_path = os.path.join(temp_dir, 'third.task.yml')
+            with open(final_config_path, 'w') as f:
+                f.write(third_config)
+            # load config - it should be identical to the task defined above
+            # patch to avoid error when loading the mock environment
+            with mock.patch.object(SavableLoadable, 'get_type',
+                                   mock.MagicMock(return_value=lambda *args, **kwargs: mock_env)):
+                sut = load_task_config(final_config_path)
+
+        # run the task to be able to check some of the parameters validity later
+        sut.run(mock_agent)
+
+        self.assertEqual('base_name', sut.name)
+        self.assertEqual(24, sut.stats.evaluation_interval)
+        self.assertEqual(f'{temp_dir}/out', sut.output_dir)
+        # stop condition
+        self.assertEqual(2, len(sut.stats.episode_rewards))
+
     def test_parameters_simple(self, mock_env: ScalableEnvironment, mock_agent: Agent):
         """
         Parameters should be substituted with provided values
@@ -415,9 +430,7 @@ class TestLoadTaskConfig(unittest.TestCase):
         # run the task to be able to check some of the parameters validity later
         sut.run(mock_agent)
 
-        self.assertEqual('Reece James', sut.name)
         self.assertEqual(24, sut.stats.evaluation_interval)
-        self.assertEqual(f'{temp_dir}/out', sut.output_dir)
         # stop condition
         self.assertEqual(2, len(sut.stats.episode_rewards))
 
@@ -444,6 +457,41 @@ class TestLoadTaskConfig(unittest.TestCase):
                     load_task_config(config_file_path, params={
                         'max_episodes': 2,
                     })
+
+    def test_parameters_in_external_files(self, mock_env: ScalableEnvironment, mock_agent: Agent):
+        """
+        Parameters should be replaced with values even if they are used in external files
+        which are loaded with the ``_load`` directive
+        """
+        with tempfile.TemporaryDirectory() as temp_dir:
+            base_task_config = (
+                "name: $name\n"
+                "evaluation_interval: 24\n"
+            )
+            new_task_config = (
+                "_load: ./base.task.yml\n"
+                "env_type: placeholder\n"
+                "env_args:\n"
+                "  difficulty: 0\n"
+                "stop_conditions:\n"
+                "  max_episodes: 2\n"
+                f"output_dir: {temp_dir}/out\n"
+            )
+            base_config_file_path = os.path.join(temp_dir, 'base.task.yml')
+            with open(base_config_file_path, 'w') as f:
+                f.write(base_task_config)
+            new_config_file_path = os.path.join(temp_dir, 'config.task.yml')
+            with open(new_config_file_path, 'w') as f:
+                f.write(new_task_config)
+            # load config - it should be identical to the task defined above
+            # patch to avoid error when loading the mock environment
+            with mock.patch.object(SavableLoadable, 'get_type',
+                                   mock.MagicMock(return_value=lambda *args, **kwargs: mock_env)):
+                sut = load_task_config(new_config_file_path, params={
+                    'name': 'my_name'
+                })
+        # assert
+        self.assertEqual('my_name', sut.name)
 
 
 if __name__ == '__main__':

--- a/test/curriculum/test_config_loaders.py
+++ b/test/curriculum/test_config_loaders.py
@@ -22,6 +22,7 @@ def _mock_load_task_config(path: str):
 def _mock_load_task_from_dict(task_data: dict):
     mock_task = mock.MagicMock()
     mock_task.name = task_data['name']
+    mock_task.output_dir = task_data.get('output_dir')
     return mock_task
 
 
@@ -35,10 +36,10 @@ def _mock_load_task_from_dict(task_data: dict):
 )
 class TestLoadCurriculumConfig(unittest.TestCase):
 
-    def test_loading_config_basic(self):
+    def test_loading_simple(self):
         """
-        ``Curriculum`` should be able to load a configuration from a YAML file.
-        In this scenario every task's configuration is in the same file.
+        ``Curriculum`` should be able to load all configuration from a YAML file
+        in the order specified by the ``order`` attribute.
         """
         with tempfile.TemporaryDirectory() as temp_dir:
             # arrange
@@ -61,16 +62,45 @@ class TestLoadCurriculumConfig(unittest.TestCase):
                 f.write(curriculum_config)
             # act
             sut = load_curriculum_config(config_file_path)
-            # assert
+        # assert
         self.assertEqual('./hello_output', sut.output_dir)
         self.assertEqual('Petr Cech', sut.tasks[0].name)
         self.assertEqual('Gary Cahill', sut.tasks[1].name)
         self.assertEqual('Cesar Azpilicueta', sut.tasks[2].name)
+        self.assertEqual(3, len(sut.tasks))
 
-    def test_loading_config_task_separate_file(self):
+    def test_task_unused(self):
         """
-        ``Curriculum`` should be able to load a configuration from a YAML file.
-        In this scenario task's configuration is in a separate file.
+        ``Curriculum`` should skip the tasks that are not listed in the ``order`` attribute.
+        """
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # arrange
+            curriculum_config = (
+                "order:\n"
+                "  - 1\n"
+                "  - 24\n"
+                "tasks:\n"  # simplified task config
+                "  28:\n"
+                "    name: Cesar Azpilicueta\n"
+                "  1:\n"
+                "    name: Petr Cech\n"
+                "  24:\n"
+                "    name: Gary Cahill"
+            )
+            config_file_path = os.path.join(temp_dir, 'config.curriculum.yml')
+            with open(config_file_path, 'w') as f:
+                f.write(curriculum_config)
+            # act
+            sut = load_curriculum_config(config_file_path)
+        # assert
+        self.assertEqual('Petr Cech', sut.tasks[0].name)
+        self.assertEqual('Gary Cahill', sut.tasks[1].name)
+        self.assertEqual(2, len(sut.tasks))
+
+    def test_load_directive_path(self):
+        """
+        The ``_load`` directive should load task configuration from a separate file if
+        the value for the directive is a path
         """
         with tempfile.TemporaryDirectory() as temp_dir:
             os.mkdir(os.path.join(temp_dir, 'curricula'))
@@ -81,7 +111,7 @@ class TestLoadCurriculumConfig(unittest.TestCase):
                 "  - 3\n"
                 "tasks:\n"
                 "  3:\n"
-                "    path: ../tasks/3.task.yml"
+                "    _load: ../tasks/3.task.yml"
             )
             config_file_path = os.path.join(temp_dir, 'curricula/config.curriculum.yml')
             with open(config_file_path, 'w') as f:
@@ -93,6 +123,179 @@ class TestLoadCurriculumConfig(unittest.TestCase):
             sut = load_curriculum_config(config_file_path)
         # assert
         self.assertEqual('Craig Forsyth', sut.tasks[0].name)
+
+    def test_load_directive_internal(self):
+        """
+        The ``_load`` directive should load other task's configuration from the same
+        ``Curriculum`` if the value for the directive is a task ID
+        """
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # arrange
+            curriculum_config = (
+                "order:\n"
+                "  - 1\n"
+                "tasks:\n"  # simplified task config
+                "  base_task:\n"
+                "    name: Petr Cech\n"
+                "  1:\n"
+                "    _load: base_task"
+            )
+            config_file_path = os.path.join(temp_dir, 'config.curriculum.yml')
+            with open(config_file_path, 'w') as f:
+                f.write(curriculum_config)
+            # act
+            sut = load_curriculum_config(config_file_path)
+        # assert
+        self.assertEqual('Petr Cech', sut.tasks[0].name)
+
+    def test_load_directive_override(self):
+        """
+        When using the ``_load`` directive and specifying other attributes as well, the specified
+        attributes should override the ones specified in the loaded task
+        """
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # arrange
+            curriculum_config = (
+                "order:\n"
+                "  - 1\n"
+                "tasks:\n"  # simplified task config
+                "  base_task:\n"
+                "    name: base_name\n"
+                "    output_dir: ./tasks\n"
+                "  1:\n"
+                "    _load: base_task\n"
+                "    name: new_name"
+            )
+            config_file_path = os.path.join(temp_dir, 'config.curriculum.yml')
+            with open(config_file_path, 'w') as f:
+                f.write(curriculum_config)
+            # act
+            sut = load_curriculum_config(config_file_path)
+        # assert
+        self.assertEqual('new_name', sut.tasks[0].name)
+        self.assertEqual('./tasks', sut.tasks[0].output_dir)
+
+    def test_parameters_simple(self):
+        """
+        Parameters should be correctly loaded
+        """
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # arrange
+            curriculum_config = (
+                "output_dir: $out\n"
+                "order:\n"
+                "  - 1\n"
+                "tasks:\n"  # simplified task config
+                "  1:\n"
+                "    name: $name"
+            )
+            config_file_path = os.path.join(temp_dir, 'config.curriculum.yml')
+            with open(config_file_path, 'w') as f:
+                f.write(curriculum_config)
+            # act
+            sut = load_curriculum_config(config_file_path, params={
+                'out': './my_curriculum',
+                'name': 'Petr Cech',
+            })
+        # assert
+        self.assertEqual('./my_curriculum', sut.output_dir)
+        self.assertEqual('Petr Cech', sut.tasks[0].name)
+
+    def test_parameter_missing(self):
+        """
+        ``NameError`` should be raised when a parameter is missing
+        """
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # arrange
+            curriculum_config = (
+                "output_dir: $out\n"
+                "order:\n"
+                "  - 1\n"
+                "tasks:\n"  # simplified task config
+                "  1:\n"
+                "    name: $name"
+            )
+            config_file_path = os.path.join(temp_dir, 'config.curriculum.yml')
+            with open(config_file_path, 'w') as f:
+                f.write(curriculum_config)
+            # act & assert
+            with self.assertRaises(NameError):
+                load_curriculum_config(config_file_path, params={
+                    'out': './my_curriculum',
+                })
+
+    def test_parameterised_full_tasks(self):
+        """
+        A curriculum task should be able to be loaded from a parameter
+        """
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # arrange
+            curriculum_config = (
+                "order:\n"
+                "  - 1\n"
+                "tasks:\n"  # simplified task config
+                "  1: $my_task\n"
+            )
+            config_file_path = os.path.join(temp_dir, 'config.curriculum.yml')
+            with open(config_file_path, 'w') as f:
+                f.write(curriculum_config)
+            # act
+            sut = load_curriculum_config(config_file_path, params={
+                'my_task': _mock_load_task_from_dict({'name': 'super_task'})
+            })
+        # assert
+        self.assertEqual('super_task', sut.tasks[0].name)
+
+    def test_parameterised_order(self):
+        """
+        Curriculum's tasks order should be able to be loaded from a parameter
+        """
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # arrange
+            curriculum_config = (
+                "order: $my_order\n"
+                "tasks:\n"  # simplified task config
+                "  1:\n"
+                "    name: Petr Cech\n"
+                "  24:\n"
+                "    name: Gary Cahill"
+            )
+            config_file_path = os.path.join(temp_dir, 'config.curriculum.yml')
+            with open(config_file_path, 'w') as f:
+                f.write(curriculum_config)
+            # act
+            sut = load_curriculum_config(config_file_path, params={
+                'my_order': ['1', '24']
+            })
+        # assert
+        self.assertEqual('Petr Cech', sut.tasks[0].name)
+        self.assertEqual('Gary Cahill', sut.tasks[1].name)
+        self.assertEqual(2, len(sut.tasks))
+
+    def test_load_directive_with_parameters(self):
+        """
+        Parameters should be loaded for tasks which use the ``_load`` directive
+        """
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # arrange
+            curriculum_config = (
+                "order:\n"
+                "  - 1\n"
+                "tasks:\n"  # simplified task config
+                "  base_task:\n"
+                "    name: $name\n"
+                "  1:\n"
+                "    _load: base_task"
+            )
+            config_file_path = os.path.join(temp_dir, 'config.curriculum.yml')
+            with open(config_file_path, 'w') as f:
+                f.write(curriculum_config)
+            # act
+            sut = load_curriculum_config(config_file_path, params={
+                'name': 'parametrised_name'
+            })
+        # assert
+        self.assertEqual('parametrised_name', sut.tasks[0].name)
 
 
 @mock.patch(
@@ -146,6 +349,101 @@ class TestLoadTaskConfig(unittest.TestCase):
         self.assertEqual(f'{temp_dir}/out', sut.output_dir)
         # stop condition
         self.assertEqual(2, len(sut.stats.episode_rewards))
+
+    def test_load_directive(self, mock_env: ScalableEnvironment, mock_agent: Agent):
+        """
+        The ``_load`` directive should load and allow to override other task configuration
+        """
+        with tempfile.TemporaryDirectory() as temp_dir:
+            base_task_config = (
+                "name: base_name\n"
+                "evaluation_interval: 24\n"
+            )
+            new_task_config = (
+                "_load: ./base.task.yml\n"
+                "env_type: placeholder\n"
+                "env_args:\n"
+                "  difficulty: 0\n"
+                "stop_conditions:\n"
+                "  max_episodes: 2\n"
+                f"output_dir: {temp_dir}/out\n"
+            )
+            base_config_file_path = os.path.join(temp_dir, 'base.task.yml')
+            with open(base_config_file_path, 'w') as f:
+                f.write(base_task_config)
+            new_config_file_path = os.path.join(temp_dir, 'config.task.yml')
+            with open(new_config_file_path, 'w') as f:
+                f.write(new_task_config)
+            # load config - it should be identical to the task defined above
+            # patch to avoid error when loading the mock environment
+            with mock.patch.object(SavableLoadable, 'get_type',
+                                   mock.MagicMock(return_value=lambda *args, **kwargs: mock_env)):
+                sut = load_task_config(new_config_file_path)
+
+        # run the task to be able to check some of the parameters validity later
+        sut.run(mock_agent)
+
+        self.assertEqual('base_name', sut.name)
+        self.assertEqual(24, sut.stats.evaluation_interval)
+        self.assertEqual(f'{temp_dir}/out', sut.output_dir)
+        # stop condition
+        self.assertEqual(2, len(sut.stats.episode_rewards))
+
+    def test_parameters_simple(self, mock_env: ScalableEnvironment, mock_agent: Agent):
+        """
+        Parameters should be substituted with provided values
+        """
+        with tempfile.TemporaryDirectory() as temp_dir:
+            task_config = ("env_type: placeholder\n"
+                           "env_args:\n"
+                           "  difficulty: 0\n"
+                           "stop_conditions:\n"
+                           "  max_episodes: $max_episodes\n"
+                           "evaluation_interval: $evaluation_int\n")
+            config_file_path = os.path.join(temp_dir, 'config.task.yml')
+            with open(config_file_path, 'w') as f:
+                f.write(task_config)
+            # load config - it should be identical to the task defined above
+            # patch to avoid error when loading the mock environment
+            with mock.patch.object(SavableLoadable, 'get_type',
+                                   mock.MagicMock(return_value=lambda *args, **kwargs: mock_env)):
+                sut = load_task_config(config_file_path, params={
+                    'max_episodes': 2,
+                    'evaluation_int': 24,
+                })
+
+        # run the task to be able to check some of the parameters validity later
+        sut.run(mock_agent)
+
+        self.assertEqual('Reece James', sut.name)
+        self.assertEqual(24, sut.stats.evaluation_interval)
+        self.assertEqual(f'{temp_dir}/out', sut.output_dir)
+        # stop condition
+        self.assertEqual(2, len(sut.stats.episode_rewards))
+
+    def test_parameter_missing(self, mock_env: ScalableEnvironment, mock_agent: Agent):
+        """
+        ``NameError`` should be raised when a parameter is missing
+        """
+        with tempfile.TemporaryDirectory() as temp_dir:
+            task_config = ("env_type: placeholder\n"
+                           "env_args:\n"
+                           "  difficulty: 0\n"
+                           "stop_conditions:\n"
+                           "  max_episodes: $max_episodes\n"
+                           "evaluation_interval: $evaluation_int\n")
+            config_file_path = os.path.join(temp_dir, 'config.task.yml')
+            with open(config_file_path, 'w') as f:
+                f.write(task_config)
+            # load config - it should be identical to the task defined above
+            # patch to avoid error when loading the mock environment
+            with mock.patch.object(SavableLoadable, 'get_type',
+                                   mock.MagicMock(return_value=lambda *args, **kwargs: mock_env)):
+                # act & assert
+                with self.assertRaises(NameError):
+                    load_task_config(config_file_path, params={
+                        'max_episodes': 2,
+                    })
 
 
 if __name__ == '__main__':

--- a/test/curriculum/test_config_loaders.py
+++ b/test/curriculum/test_config_loaders.py
@@ -70,6 +70,28 @@ class TestLoadCurriculumConfig(unittest.TestCase):
         self.assertEqual('Cesar Azpilicueta', sut.tasks[2].name)
         self.assertEqual(3, len(sut.tasks))
 
+    def test_name_error_when_task_missing(self):
+        """
+        NameError should be raised when a task is referenced in the order which has
+        not been defined in this curriculum
+        """
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # arrange
+            curriculum_config = (
+                "output_dir: ./hello_output\n"
+                "order:\n"
+                "  - 1\n"
+                "tasks:\n"  # simplified task config
+                "  28:\n"
+                "    name: Cesar Azpilicueta\n"
+            )
+            config_file_path = os.path.join(temp_dir, 'config.curriculum.yml')
+            with open(config_file_path, 'w') as f:
+                f.write(curriculum_config)
+            # act & assert
+            with self.assertRaises(NameError):
+                load_curriculum_config(config_file_path)
+
     def test_task_unused(self):
         """
         ``Curriculum`` should skip the tasks that are not listed in the ``order`` attribute.

--- a/test/curriculum/test_config_loaders.py
+++ b/test/curriculum/test_config_loaders.py
@@ -150,9 +150,9 @@ class TestLoadCurriculumConfig(unittest.TestCase):
         self.assertEqual('new_name', sut.tasks[0].name)
         self.assertEqual('./tasks', sut.tasks[0].output_dir)
 
-    def test_parameters_simple(self):
+    def test_variables_simple(self):
         """
-        Parameters should be correctly loaded
+        Variables should be correctly loaded
         """
         with tempfile.TemporaryDirectory() as temp_dir:
             # arrange
@@ -168,7 +168,7 @@ class TestLoadCurriculumConfig(unittest.TestCase):
             with open(config_file_path, 'w') as f:
                 f.write(curriculum_config)
             # act
-            sut = load_curriculum_config(config_file_path, params={
+            sut = load_curriculum_config(config_file_path, variables={
                 'out': './my_curriculum',
                 'name': 'Alfie May is a baller',
             })
@@ -176,9 +176,9 @@ class TestLoadCurriculumConfig(unittest.TestCase):
         self.assertEqual('./my_curriculum', sut.output_dir)
         self.assertEqual('Alfie May is a baller', sut.tasks[0].name)
 
-    def test_parameter_missing(self):
+    def test_variables_missing(self):
         """
-        ``NameError`` should be raised when a parameter is missing
+        ``NameError`` should be raised when a variable is missing
         """
         with tempfile.TemporaryDirectory() as temp_dir:
             # arrange
@@ -195,13 +195,13 @@ class TestLoadCurriculumConfig(unittest.TestCase):
                 f.write(curriculum_config)
             # act & assert
             with self.assertRaises(NameError):
-                load_curriculum_config(config_file_path, params={
+                load_curriculum_config(config_file_path, variables={
                     'out': './my_curriculum',
                 })
 
-    def test_parameterised_full_tasks_data(self):
+    def test_variable_full_tasks_data(self):
         """
-        A curriculum task data should be able to be loaded from a parameter
+        A curriculum task data should be able to be loaded from a variable
         """
         with tempfile.TemporaryDirectory() as temp_dir:
             # arrange
@@ -215,15 +215,15 @@ class TestLoadCurriculumConfig(unittest.TestCase):
             with open(config_file_path, 'w') as f:
                 f.write(curriculum_config)
             # act
-            sut = load_curriculum_config(config_file_path, params={
+            sut = load_curriculum_config(config_file_path, variables={
                 'my_task': {'name': 'super_task'},
             })
         # assert
         self.assertEqual('super_task', sut.tasks[0].name)
 
-    def test_parameterised_full_tasks_obj(self):
+    def test_variable_full_tasks_obj(self):
         """
-        A curriculum task should be able to be loaded from a parameter directly as an object
+        A curriculum task should be able to be loaded from a variable directly as an object
         """
         with tempfile.TemporaryDirectory() as temp_dir:
             # arrange
@@ -237,15 +237,15 @@ class TestLoadCurriculumConfig(unittest.TestCase):
             with open(config_file_path, 'w') as f:
                 f.write(curriculum_config)
             # act
-            sut = load_curriculum_config(config_file_path, params={
+            sut = load_curriculum_config(config_file_path, variables={
                 'my_task': _mock_load_task_from_dict({'name': 'super_task'}),
             })
         # assert
         self.assertEqual('super_task', sut.tasks[0].name)
 
-    def test_parameterised_order(self):
+    def test_variable_order(self):
         """
-        Curriculum's tasks order should be able to be loaded from a parameter
+        Curriculum's tasks order should be able to be loaded from a variable
         """
         with tempfile.TemporaryDirectory() as temp_dir:
             # arrange
@@ -261,7 +261,7 @@ class TestLoadCurriculumConfig(unittest.TestCase):
             with open(config_file_path, 'w') as f:
                 f.write(curriculum_config)
             # act
-            sut = load_curriculum_config(config_file_path, params={
+            sut = load_curriculum_config(config_file_path, variables={
                 'my_order': [1, 24]
             })
         # assert
@@ -404,9 +404,9 @@ class TestLoadTaskConfig(unittest.TestCase):
         # stop condition
         self.assertEqual(2, len(sut.stats.episode_rewards))
 
-    def test_parameters_simple(self, mock_env: ScalableEnvironment, mock_agent: Agent):
+    def test_variables_simple(self, mock_env: ScalableEnvironment, mock_agent: Agent):
         """
-        Parameters should be substituted with provided values
+        Variables should be substituted with provided values
         """
         with tempfile.TemporaryDirectory() as temp_dir:
             task_config = ("env_type: placeholder\n"
@@ -422,7 +422,7 @@ class TestLoadTaskConfig(unittest.TestCase):
             # patch to avoid error when loading the mock environment
             with mock.patch.object(SavableLoadable, 'get_type',
                                    mock.MagicMock(return_value=lambda *args, **kwargs: mock_env)):
-                sut = load_task_config(config_file_path, params={
+                sut = load_task_config(config_file_path, variables={
                     'max_episodes': 2,
                     'evaluation_int': 24,
                 })
@@ -434,9 +434,9 @@ class TestLoadTaskConfig(unittest.TestCase):
         # stop condition
         self.assertEqual(2, len(sut.stats.episode_rewards))
 
-    def test_parameter_missing(self, mock_env: ScalableEnvironment, mock_agent: Agent):
+    def test_variable_missing(self, mock_env: ScalableEnvironment, mock_agent: Agent):
         """
-        ``NameError`` should be raised when a parameter is missing
+        ``NameError`` should be raised when a variable is missing
         """
         with tempfile.TemporaryDirectory() as temp_dir:
             task_config = ("env_type: placeholder\n"
@@ -454,13 +454,13 @@ class TestLoadTaskConfig(unittest.TestCase):
                                    mock.MagicMock(return_value=lambda *args, **kwargs: mock_env)):
                 # act & assert
                 with self.assertRaises(NameError):
-                    load_task_config(config_file_path, params={
+                    load_task_config(config_file_path, variables={
                         'max_episodes': 2,
                     })
 
-    def test_parameters_in_external_files(self, mock_env: ScalableEnvironment, mock_agent: Agent):
+    def test_variables_in_external_files(self, mock_env: ScalableEnvironment, mock_agent: Agent):
         """
-        Parameters should be replaced with values even if they are used in external files
+        Variables should be replaced with values even if they are used in external files
         which are loaded with the ``_load`` directive
         """
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -487,7 +487,7 @@ class TestLoadTaskConfig(unittest.TestCase):
             # patch to avoid error when loading the mock environment
             with mock.patch.object(SavableLoadable, 'get_type',
                                    mock.MagicMock(return_value=lambda *args, **kwargs: mock_env)):
-                sut = load_task_config(new_config_file_path, params={
+                sut = load_task_config(new_config_file_path, variables={
                     'name': 'my_name'
                 })
         # assert

--- a/test/curriculum/test_config_loaders.py
+++ b/test/curriculum/test_config_loaders.py
@@ -128,8 +128,7 @@ class TestLoadTaskConfig(unittest.TestCase):
                            "  max_episodes: 2\n"
                            "evaluation_interval: 24\n"
                            "name: Reece James\n"
-                           f"agent_save_path: {temp_dir}/secret_agent_123\n"
-                           f"stats_save_path: {temp_dir}/super_stats_321")
+                           f"output_dir: {temp_dir}/out\n")
             config_file_path = os.path.join(temp_dir, 'config.task.yml')
             with open(config_file_path, 'w') as f:
                 f.write(task_config)
@@ -144,8 +143,7 @@ class TestLoadTaskConfig(unittest.TestCase):
 
         self.assertEqual('Reece James', sut.name)
         self.assertEqual(24, sut.stats.evaluation_interval)
-        self.assertEqual(f'{temp_dir}/secret_agent_123', sut.agent_save_path)
-        self.assertEqual(f'{temp_dir}/super_stats_321', sut.stats_save_path)
+        self.assertEqual(f'{temp_dir}/out', sut.output_dir)
         # stop condition
         self.assertEqual(2, len(sut.stats.episode_rewards))
 

--- a/test/curriculum/test_curriculum.py
+++ b/test/curriculum/test_curriculum.py
@@ -1,7 +1,6 @@
 from typing import Optional
 import unittest
 from unittest import mock
-import os
 
 from academia.curriculum import Curriculum
 
@@ -42,24 +41,25 @@ class TestCurriculum(unittest.TestCase):
         self.assertEqual(['1', 'John Terry', '3'], list(stats_dict_keys))
 
     @mock.patch('academia.agents.base.Agent')
-    def test_save_paths_override(self, mock_agent):
+    def test_output_config_override(self, mock_agent):
         """
-        Curriculum should override task's save paths if and only if they're not specified for that task.
+        Curriculum should override task's output_dir and name if and only if
+        they're not specified for that task.
         """
         # arrange
-        task1, task2 = _get_mock_learning_tasks(['task_with_agent_path', 'task_with_stats_path'])
-        task1.agent_save_path = './my_agent'
-        task1.stats_save_path = None
-        task2.stats_save_path = './my_stats'
-        task2.agent_save_path = None
+        task1, task2 = _get_mock_learning_tasks(['task_with_output_dir', 'task_with_name'])
+        task1.output_dir = './task1'
+        task1.name = None
+        task2.output_dir = None
+        task2.name = 'task2'
         # act
         sut = Curriculum([task1, task2], output_dir='./my_curriculum')
         sut.run(mock_agent)
         # assert
-        self.assertEqual('./my_agent', task1.agent_save_path)
-        self.assertEqual(os.path.join('./my_curriculum', 'task_with_agent_path'), task1.stats_save_path)
-        self.assertEqual(os.path.join('./my_curriculum', 'task_with_stats_path'), task2.agent_save_path)
-        self.assertEqual('./my_stats', task2.stats_save_path)
+        self.assertEqual('./task1', task1.output_dir)
+        self.assertEqual('1', task1.name)
+        self.assertEqual('./my_curriculum', task2.output_dir)
+        self.assertEqual('task2', task2.name)
 
 
 if __name__ == '__main__':

--- a/test/curriculum/test_curriculum.py
+++ b/test/curriculum/test_curriculum.py
@@ -61,6 +61,54 @@ class TestCurriculum(unittest.TestCase):
         self.assertEqual('./my_curriculum', task2.output_dir)
         self.assertEqual('task2', task2.name)
 
+    @mock.patch('academia.agents.base.Agent')
+    def test_task_callback_triggering(self, mock_agent):
+        """
+        Task callback should trigger after every task.
+        """
+        tracking_list = []
+
+        def task_callback(agent, stats, task_id):
+            tracking_list.append(task_id)
+
+        # arrange
+        task1, task2, task3 = _get_mock_learning_tasks(['1', '2', '3'])
+        sut = Curriculum([task1, task2, task3], task_callback=task_callback)
+        # act
+        sut.run(mock_agent)
+        # assert
+        self.assertEqual(['1', '2', '3'], tracking_list,
+                         msg='Task callback triggered an incorrect number of times')
+
+    @mock.patch('academia.agents.base.Agent')
+    def test_task_callback_agent_overwrite(self, mock_agent):
+        """
+        Task callback should be able to overwrite the currently used agent
+        """
+        was_new_agent_used = False
+
+        def task_callback(agent, stats, task_id):
+            def get_action(*args, **kwargs):
+                nonlocal was_new_agent_used
+                was_new_agent_used = True
+
+            new_agent = mock.MagicMock()
+            new_agent.get_action = get_action
+            return new_agent
+
+        # arrange
+        task1, task2 = _get_mock_learning_tasks([None, None])
+
+        def task2_run(agent, *args, **kwargs):
+            agent.get_action()
+
+        task2.run = task2_run
+        sut = Curriculum([task1, task2], task_callback=task_callback)
+        # act
+        sut.run(mock_agent)
+        # assert
+        self.assertTrue(was_new_agent_used, msg='New agent was not used')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR adds new features to the curriculum module, most notably regarding configuration files.

Changes regarding configuration files (closes #195):
- Interpret `_default` task as a container for default task parameter values for all tasks in curriculum;
- Allow loading attributes from external YAML files with the `_load` special attribute (I called it "directive" in code for short). This is a versatile replacement for the old `path` attribute.;
- Allow the use of variables inside configurations. Variables are denoted by a dollar sign `$` and their values are assigned upon loading using a `variables` dictionary which is a parameter for both `load_task_config()` and `load_curriculum_config()`;
- All changes are accommodated by the `academia.curriculum.config_loaders` submodule, which replaced `LearningTask.load()` and `Curriculum.load()` in #243;
- **I recommend you read a guide in our docs regarding these changes to better understand them (titled "Configuring tasks & curricula"). This guide is also a part of this PR**.

Other changes:
- Closes #177. To specify filenames, `LearningTask.name` is used (e.g. stats are saved as `{LearningTask.name}.stats.json`);
- I accidentally discovered that `return False` was missing from `LearningTask.__is_finished()` and the method was working only because `None` is a falsy value. This has now been added;
- Add `task_callback` for `Curriculum` and `episode_callback` for `LearningTask`, as described in the thesis (closes #244 and #230);
- Remove `exploration_reset_value` from `LearningTask` - now redundant since task callbacks were added;
- Raise NameError (instead of default KeyError) when an undefined task is referenced in the `order` attribute of a Curriculum configuration (this makes this error clearer for the end user);
- Minor code refactoring regarding handling task interruption (no change in behaviour).