### PR TITLE
Address the warning from `torch.load` regarding `weights_only`

### DIFF
--- a/academia/agents/dqn_agent.py
+++ b/academia/agents/dqn_agent.py
@@ -373,8 +373,14 @@ class DQNAgent(EpsilonGreedyAgent):
         with tempfile.TemporaryDirectory() as tempdir:
             zf.extractall(tempdir)
             # network state
-            network_params = torch.load(os.path.join(tempdir, 'network.pth'))
-            target_network_params = torch.load(os.path.join(tempdir, 'target_network.pth'))
+            network_params = torch.load(
+                os.path.join(tempdir, 'network.pth'),
+                weights_only=True,
+            )
+            target_network_params = torch.load(
+                os.path.join(tempdir, 'target_network.pth'),
+                weights_only=True,
+            )
             # agent config
             with open(os.path.join(tempdir, 'state.agent.json'), 'r') as file:
                 params = json.load(file)

--- a/academia/agents/ppo_agent.py
+++ b/academia/agents/ppo_agent.py
@@ -498,8 +498,14 @@ class PPOAgent(Agent):
         with tempfile.TemporaryDirectory() as tempdir:
             zf.extractall(tempdir)
             
-            actor_params = torch.load(os.path.join(tempdir, 'actor.pth'))
-            critic_params = torch.load(os.path.join(tempdir, 'critic.pth'))
+            actor_params = torch.load(
+                os.path.join(tempdir, 'actor.pth'),
+                weights_only=True,
+            )
+            critic_params = torch.load(
+                os.path.join(tempdir, 'critic.pth'),
+                weights_only=True,
+            )
             
             with open(os.path.join(tempdir, 'state.agent.json'), 'r') as file:
                 agent_state = json.load(file)


### PR DESCRIPTION
The warning said:

```FutureWarning: You are using `torch.load` with `weights_only=False` (the current default value), which uses the default pickle module implicitly. It is possible to construct malicious pickle data which will execute arbitrary code during unpickling (See https://github.com/pytorch/pytorch/blob/main/SECURITY.md#untrusted-models for more details). In a future release, the default value for `weights_only` will be flipped to `True`. This limits the functions that could be executed during unpickling. Arbitrary objects will no longer be allowed to be loaded via this mode unless they are explicitly allowlisted by the user via `torch.serialization.add_safe_globals`. We recommend you start setting `weights_only=True` for any use case where you don't have full control of the loaded file. Please open an issue on GitHub for any issues related to this experimental feature. network_params = torch.load(os.path.join(tempdir, 'network.pth'))```

All tests still pass so I assume this change did not break anything.