### PR TITLE
Improve environment wrappers docs (add notes on extra packages required)

### DIFF
--- a/academia/environments/door_key.py
+++ b/academia/environments/door_key.py
@@ -10,6 +10,11 @@ class DoorKey(GenericMiniGridWrapper):
     """
     This class is a wrapper for *MiniGrid*'s Door Key environments.
 
+    Note:
+        MiniGrid package is required to use this environment.
+
+        You can install it using ``pip install minigrid``.
+
     DoorKey is a grid environment where an agent has to find a key and then open a door to reach the
     destination. The higher the difficulty, the bigger the grid so it is more complicated to find the key,
     then the door and then the destination.

--- a/academia/environments/lava_crossing.py
+++ b/academia/environments/lava_crossing.py
@@ -10,6 +10,11 @@ class LavaCrossing(GenericMiniGridWrapper):
     """
     This class is a wrapper for *MiniGrid*'s Lava Crossing environments.
 
+    Note:
+        MiniGrid package is required to use this environment.
+
+        You can install it using ``pip install minigrid``.
+
     A grid environment where an agent has to avoid patches of lava in order to
     reach the destination. The higher the difficulty, the more lava patches are
     generated on the grid.

--- a/academia/environments/lunar_lander.py
+++ b/academia/environments/lunar_lander.py
@@ -11,6 +11,11 @@ class LunarLander(GenericGymnasiumWrapper):
     This class is a wrapper for *Gymnasium*'s Lunar Lander environment, which itself is
     a variant of the classic Lunar Lander game.
 
+    Note:
+        Box2D dependency for Gymnasium is required to use this environment.
+
+        You can install it using ``pip install gymnasium[box2d]``.
+
     The goal is to land a spacecraft on the moon's surface by controlling its thrusters.
     The environment has a state size of 8 and 4 possible actions.
     The difficulty ranges from 0 to 5, with higher values indicating more challenging conditions.

--- a/academia/environments/ms_pacman.py
+++ b/academia/environments/ms_pacman.py
@@ -10,6 +10,11 @@ class MsPacman(GenericAtariWrapper):
     """
     This class is a wrapper for *Gymnasium*'s Ms Pacman environment.
 
+    Note:
+        You need extra packages to use this environment.
+
+        You can install them using ``pip install "gymnasium[atari, accept-rom-license]"``
+
     MsPacman is an Atari 2600 environment where the agent has to navigate a maze, eat pellets
     and avoid ghosts. The higher the difficulty, the more ghosts to avoid.
 

--- a/academia/environments/ms_pacman.py
+++ b/academia/environments/ms_pacman.py
@@ -14,6 +14,7 @@ class MsPacman(GenericAtariWrapper):
         You need extra packages to use this environment.
 
         You can install them using ``pip install "gymnasium[atari, accept-rom-license]"``
+        Please note that this might not work on Python 3.12.
 
     MsPacman is an Atari 2600 environment where the agent has to navigate a maze, eat pellets
     and avoid ghosts. The higher the difficulty, the more ghosts to avoid.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ classifiers = [
 ]
 dependencies = [
     "gymnasium ~=0.29",
-    "minigrid ~=2.3",
     "kaleido ~=0.2",
     "numpy ~=1.25",
     "plotly ~=5.18",


### PR DESCRIPTION
I also removed minigrid from dependencies which I added earlier (I realised it is not actually required to import any packages, it is just to run the relevant environments, so if someone is not going to use these they do not need minigrid)