### PR TITLE
Bump version and add Python 3.12 to package classifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ packages = ["./academia"]
 
 [project]
 name = "academia-rl"
-version = "0.1.0"
+version = "0.2.0"
 authors = [
     { name="krezelj", email="jasiekk9@gmail.com" },
     { name="guts", email="szymon.gut01@gmail.com" },
@@ -25,6 +25,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Intended Audience :: Science/Research",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ version = "0.2.0"
 authors = [
     { name="krezelj", email="jasiekk9@gmail.com" },
     { name="guts", email="szymon.gut01@gmail.com" },
-    { name="maciejors", email="maciej.orslowski@gmail.con" },
+    { name="maciejors", email="maciej.orslowski@gmail.com" },
 ]
 description = "Easy-to-use tools for Curriculum Learning"
 readme = "README.md"


### PR DESCRIPTION
I just put this here in advance, it will be merged once all other PRs are merged since I think these new changes are going to be enough for a new release (plus I am personally not planning on any further expansions in the near future, and I'm not sure if any of you are)